### PR TITLE
Fixes unknown locale key "fire-hazard-concrete"

### DIFF
--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -9,10 +9,7 @@ concrete-purple=Purple Concrete
 concrete-magenta=Magenta Concrete
 concrete-white=White Concrete
 concrete-black=Black Concrete
-concrete-hazard-left=Hazard Marking Concrete (Left)
-concrete-hazard-right=Hazard Marking Concrete (Right)
-concrete-fire-left=Fire Marking Concrete (Left)
-concrete-fire-right=Fire Marking Concrete (Right)
+fire-hazard-concrete=Fire Hazard Concrete
 
 small-lamp-red=Red Indicator Lamp
 small-lamp-orange=Orange Indicator Lamp
@@ -39,6 +36,7 @@ concrete-purple=Purple Concrete
 concrete-magenta=Magenta Concrete
 concrete-white=White Concrete
 concrete-black=Black Concrete
+fire-hazard-concrete=Fire Hazard Concrete
 
 small-lamp-red=Red Indicator Lamp
 small-lamp-orange=Orange Indicator Lamp
@@ -79,5 +77,4 @@ concrete-purple=Purple Concrete
 concrete-magenta=Magenta Concrete
 concrete-white=White Concrete
 concrete-black=Black Concrete
-concrete-fire-left=Fire Marking Concrete (Left)
-concrete-fire-right=Fire Marking Concrete (Right)
+fire-hazard-concrete=Fire Hazard Concrete


### PR DESCRIPTION
I haven't tested this but it just adds back the locale keys that got removed in the commit revert so it should be fine.
